### PR TITLE
removed `php-cs-fixer` config from dist-release

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,15 +9,16 @@
 *.neon.dist   diff=yaml
 
 # files that are not bundled into the "dist" release are marked `export-ignore`
-.gitattributes      export-ignore
-.gitignore          export-ignore
-.editorconfig       export-ignore
-/.github            export-ignore
-/.phive             export-ignore
-/examples           export-ignore
-/tests              export-ignore
-/tools              export-ignore
-/.php_cs.dist       export-ignore
-/phpunit.xml.dist   export-ignore
-/psalm.xml.dist     export-ignore
-/HISTORY.md         export-ignore
+.gitattributes          export-ignore
+.gitignore              export-ignore
+.editorconfig           export-ignore
+/.github                export-ignore
+/.phive                 export-ignore
+/examples               export-ignore
+/tests                  export-ignore
+/tools                  export-ignore
+/.php_cs.dist           export-ignore
+/.php-cs-fixer.dist.php export-ignore
+/phpunit.xml.dist       export-ignore
+/psalm.xml.dist         export-ignore
+/HISTORY.md             export-ignore

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,11 @@
 # Changes
 
+## 1.0.3
+
+Maintenance release:
+* Misc
+  * removed `php-cs-fixer` config from dist-release.
+
 ## 1.0.2
 
 Maintenance release:


### PR DESCRIPTION
this would cause a maintenance release as 1.0.3
the latest changes were added in the HISTORY.md (see changes in here)