### PR TITLE
make dev-tools php requirement clear

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -98,7 +98,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php:
+        php-version:
           - '8.2' # highest supported
           - '7.3' # lowest supported
     steps:
@@ -109,7 +109,7 @@ jobs:
         # see https://github.com/shivammathur/setup-php
         uses: shivammathur/setup-php@v2
         with:
-          php-version: ${{ matrix.php }}
+          php-version: ${{ env.PHP_VERSION_LATEST }}
           tools: composer
           coverage: none
       - name: Install psalm
@@ -134,7 +134,8 @@ jobs:
           --no-diff
           --no-cache
           --long-progress
-          --report=${{ env.REPORTS_DIR }}/psalm.php${{ matrix.php }}.junit.xml
+          --php-version=${{ matrix.php-version }}
+          --report=${{ env.REPORTS_DIR }}/psalm.php${{ matrix.php-version }}.junit.xml
       - name: Artifact reports
         if: ${{ ! cancelled() }}
         # see https://github.com/actions/upload-artifact
@@ -155,7 +156,7 @@ jobs:
         # see https://github.com/shivammathur/setup-php
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'  # not ready for php82 ${{ env.PHP_VERSION_LATEST }}
+          php-version: ${{ env.PHP_VERSION_LATEST }}
           tools: composer
           coverage: none
       - name: Install PHP-CS-Fixer

--- a/tools/composer-normalize/composer.json
+++ b/tools/composer-normalize/composer.json
@@ -2,6 +2,9 @@
     "name": "tools/composer-normalize",
     "description": "composer-normalize",
     "type": "metapackage",
+    "require": {
+        "php": ">=7.4"
+    },
     "require-dev": {
         "ergebnis/composer-normalize": "2.28.3",
         "roave/security-advisories": "dev-latest"

--- a/tools/composer-require-checker/composer.json
+++ b/tools/composer-require-checker/composer.json
@@ -2,6 +2,9 @@
     "name": "tools/composer-require-checker",
     "description": "composer-require-checker",
     "type": "metapackage",
+    "require": {
+        "php": ">=7.4"
+    },
     "require-dev": {
         "maglnet/composer-require-checker": "3.8.0",
         "roave/security-advisories": "dev-latest"

--- a/tools/composer-unused/composer.json
+++ b/tools/composer-unused/composer.json
@@ -2,6 +2,9 @@
     "name": "tools/composer-unused",
     "description": "composer-unused",
     "type": "metapackage",
+    "require": {
+        "php": ">=7.4"
+    },
     "require-dev": {
         "icanhazstring/composer-unused": "0.8.10",
         "roave/security-advisories": "dev-latest"

--- a/tools/php-cs-fixer/composer.json
+++ b/tools/php-cs-fixer/composer.json
@@ -2,6 +2,9 @@
     "name": "tools/php-cs-fixer",
     "description": "php-cs-fixer",
     "type": "metapackage",
+    "require": {
+        "php": ">=7.4"
+    },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "3.21.0",
         "roave/security-advisories": "dev-latest"

--- a/tools/psalm/composer.json
+++ b/tools/psalm/composer.json
@@ -2,6 +2,9 @@
     "name": "tools/psalm",
     "description": "psalm and plugins",
     "type": "metapackage",
+    "require": {
+        "php": ">=7.4"
+    },
     "require-dev": {
         "roave/security-advisories": "dev-latest",
         "vimeo/psalm": "4.30.0"


### PR DESCRIPTION
the file `CONTRIBUTING.md` states 
```md
Even though the code base itself is php 7.3 compatible,
the setup of this project for development purposes requires php >= 7.4.
```

to make this more clear, the php constraints were added to composer manifest files.